### PR TITLE
Fixes the issue of a malformed sources file in the jessie image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM grahamdumpleton/mod-wsgi-docker:python-3.5-onbuild
 
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get -y install unzip
 


### PR DESCRIPTION
There is an issue with the Jessie image, trying to update the apt repositories.  New sources need to be added to correct this (the archive).  Running this command at the begging of the Dockerfile adds these sources properly so the build can succeed.